### PR TITLE
autoconf 2.71

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - sk_test

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - sk_test

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 ./configure --prefix=${PREFIX}        \
             --libdir=${PREFIX}/lib    \
             --build=${BUILD}          \

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-set -e
+set -xe
 
 ./configure --prefix=${PREFIX}        \
             --libdir=${PREFIX}/lib    \
@@ -9,6 +9,7 @@ set -e
             PERL='/usr/bin/env perl'
 
 make -j${CPU_COUNT} ${VERBOSE_AT}
+
 # If CONFIG_SITE is not specified, it will pick up your system's default one
 # and if you are running a 64-bit system that uses /usr/lib64, then test 231
 # in base.at, called "configure directories" will fail since it is hardcoded

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,6 +32,8 @@ requirements:
     - perl 5.*
 
 test:
+  requires:
+    - conda-build  # [osx]
   commands:
     - autoconf --help
     - conda inspect linkages -p $PREFIX autoconf  # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.69" %}
+{% set version = "2.71" %}
 
 package:
   name: autoconf
@@ -8,34 +8,28 @@ source:
   # Please keep these lines around. They are used to rebase the patches
   # easily. Unfortunately, autoconf requires autotools to build itself.
   # git_url: http://git.sv.gnu.org/r/autoconf.git
-  # git_tag: v2.69
-  url: http://ftp.gnu.org/gnu/autoconf/autoconf-{{ version }}.tar.gz
-  sha256: 954bd69b391edc12d6a4a51a2dd1476543da5c6bbf05a95b59dc0dd6fd4c2969
-  patches:
-    - 0001-autoscan-port-to-perl-5.17.patch
-    - 0002-tests-avoid-spurious-test-failure-with-libtool-2.4.3.patch
-    - 0003-Patch-shebang.patch
-    - 0004-Add-use-lib-.-to-auto-scan-header-.in.patch
+  # git_tag: v2.71
+  url: https://ftp.gnu.org/gnu/autoconf/autoconf-{{ version }}.tar.gz
+  sha256: 431075ad0bf529ef13cb41e9042c542381103e80015686222b8a9d4abef42a1c
 
 build:
-  number: 5
+  number: 0
   skip: True  # [win]
 
 requirements:
-  host:
-    - m4
-    - perl
-    #  make check requirement:
-    - {{ compiler('c') }}
   build:
     #  make check requirement:
     - make
     - libtool
     - patch     # [not win]
-    - m2-patch  # [win]
+  host:
+    #  make check requirement:
+    - {{ compiler('c') }}
+    - m4
+    - perl 5.*
   run:
     - m4
-    - perl
+    - perl 5.*
 
 test:
   commands:
@@ -44,17 +38,18 @@ test:
     - conda inspect objects -p $PREFIX autoconf   # [osx]
 
 about:
-  home: http://www.gnu.org/software/autoconf/
-  license: GPL-3.0
+  home: https://www.gnu.org/software/autoconf/
+  license: GPL-3.0-or-later WITH Autoconf-exception-3.0
+  license_family: GPL
   license_file: COPYING
-  summary: 'Extensible M4 macros that produce shell scripts to configure software source code packages.'
+  summary: Extensible M4 macros that produce shell scripts to configure software source code packages.
   description: |
     Autoconf is a tool for producing shell scripts that automatically configure
     software source code packages to adapt to many kinds of Posix-like systems.
     The configuration scripts produced by Autoconf are independent of Autoconf
     when they are run, so their users do not need to have Autoconf.
   doc_url: https://www.gnu.org/software/autoconf/manual/autoconf.html
-  dev_url: http://git.sv.gnu.org/r/autoconf.git
+  dev_url: https://git.savannah.gnu.org/r/autoconf.git/
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -60,3 +60,5 @@ extra:
     - jakirkham
     - ocefpaf
     - mingwandroid
+  skip-lints:
+    - compilers_must_be_in_build

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,8 +33,10 @@ requirements:
 
 test:
   requires:
+  # For conda inspect command
     - conda-build  # [osx]
   commands:
+    - autoconf --version
     - autoconf --help
     - conda inspect linkages -p $PREFIX autoconf  # [not win]
     - conda inspect objects -p $PREFIX autoconf   # [osx]


### PR DESCRIPTION
**Autoconf** is a **build** tool. It must be updated with other build tools:
`autoconf` -> `automake` https://github.com/AnacondaRecipes/automake-feedstock/pull/5 -> `libtool` https://github.com/AnacondaRecipes/libtool-feedstock/pull/4

Actions:
1. Add `set -xe` command (print shell command before executing it and exit immediately if it fails) https://www.gnu.org/savannah-checkouts/gnu/bash/manual/bash.html#The-Set-Builtin
2. Remove outdated patches
3. Fix `source/url` with HTTPS
4. Reset build number
5. Move `host` section for readability
6. Remove `m2-patch  # [win] a`s we don't build for windows
7. Add `perl 5.*` to host
8. Add `conda-build  # [osx]` to `test/requires` for `conda inspect` command
9. Update home and dev urls
10. Update `license`
11. Add `license_family`
12. Add `compilers_must_be_in_build` to `skip-lints`